### PR TITLE
match_dashes

### DIFF
--- a/mysql_
+++ b/mysql_
@@ -1399,7 +1399,7 @@ sub parse_innodb_status {
 my $innodb_bigint_rx = qr{([[a-fA-F\d]+)(?: (\d+))?};
 
 
-sub match_dashes { return m/\G-+\n/gc; }
+sub match_dashes { return m/\G-{4,}\n/gc; }
 
 
 sub skip_line    { return m/\G.*\n/gc; }


### PR DESCRIPTION
Ran into a problem with the plugin today where that if there was a deadlock it would match lines that began with "--TRANSACTION 0 392007129, "

changed the regex so there has to be at least 4 dashes for it to match
