### PR TITLE
graph namespace kollisjon

### DIFF
--- a/mysql
+++ b/mysql
@@ -221,7 +221,7 @@ sub main {
             collect_data();
         }
         for my $graph (sort keys %graphs) {
-            print "multigraph $graph$instance\n";
+            print "multigraph mysql_$graph$instance\n";
             $command_map{$command}->($graph);
         }
     }


### PR DESCRIPTION
Hei,

mysql plugin i multigraph versjon har en "uptime" graf.  Denne kolliderer med pluginen "uptime" fordi de bruker samme namespace.  Alle mysql plugin'ens grafer bør definitivt være prefikset med mysql_ - som de var før også.

Mvh,
  Nicolai
