### PR TITLE
Added possibility to add a postfix to graph titles when monitoring multiple servers

### DIFF
--- a/mysql
+++ b/mysql
@@ -36,7 +36,8 @@ For example:
 
 This plugin can monitor many instances of MySQL. See 
 L<http://github.com/kjellm/munin-mysql/issues#issue/22> for a hint on
-how this can be configured.
+how this can be configured. In this case you can also set env.titlepostfix
+for distinguishing the different servers in their graph titles.
 
 =head2 Slave lag (mk-heartbeat, pt-heartbeat)
 
@@ -272,7 +273,11 @@ sub config {
     $conf{args} .=  ' --no-gridfit --slope-mode';
 
     while (my ($k, $v) = each %conf) {
-        print "graph_$k $v\n";
+    	if ($k eq 'title') {
+    	    print "graph_$k $v $ENV{'titlepostfix'}\n";
+    	} else {
+            print "graph_$k $v\n";
+    	}
     }
     print "graph_category mysql$instance\n";
 


### PR DESCRIPTION
When running the plugin from an external host where the MySQL database is not running on and when you are using this plugin to monitor multiple instances, all graph titles look the same:

```
my.server.com :: MySQL Commands
```

With this patch you can use different postfixes in the environment:

```
env.titlepostfix Master
```

This example would result in the following title:

```
my.server.com :: MySQL Commands Master
```
